### PR TITLE
Fix Sass deprecation warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,8 @@ url: https://carlosespejo.com
 github_username: CarlosEspejo
 theme: jekyll-theme-slate
 timezone: America/New_York
+sass:
+  quiet_deps: true
 kramdown:
   input: GFM
   hard_wrap: false

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,4 @@
+---
+---
+
+@use "jekyll-theme-slate";


### PR DESCRIPTION
## Summary
- Add `sass: quiet_deps: true` to suppress `@import` warnings from inside `jekyll-theme-slate` gem
- Override `assets/css/style.scss` with `@use` instead of `@import` to silence the root stylesheet warning

## Test plan
- [x] `bundle exec jekyll build` produces zero deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)