### PR TITLE
Use path-style title separator: Carlos Espejo / Page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% if page.title %}{{ page.title }} // Carlos Espejo{% else %}Carlos Espejo{% endif %}</title>
+  <title>{% if page.title %}Carlos Espejo / {{ page.title }}{% else %}Carlos Espejo{% endif %}</title>
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   {% feed_meta %}
   {% seo %}


### PR DESCRIPTION
## Summary
- Reverse page title order to follow path convention (`Carlos Espejo / My Journey` instead of `My Journey // Carlos Espejo`)
- Matches the `~/CarlosEspejo $` terminal nav theme

## Test plan
- [x] Verify subpage tabs read `Carlos Espejo / My Journey`, `Carlos Espejo / What I Wish I Had`, etc.
- [x] Verify homepage tab reads `Carlos Espejo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)