### PR TITLE
Fix journey page copy: Silicon Alley and AVP titles

### DIFF
--- a/journey.html
+++ b/journey.html
@@ -164,7 +164,7 @@ title: My Journey
 <div class="journey">
 
   <div class="journey-header">
-    <p>From Santiago to Silicon Alley, a first-gen kid's path through Brooklyn, college, and a career in tech.</p>
+    <p>From Santiago to New York City, a first-gen kid's path through Brooklyn, college, and a career in tech.</p>
   </div>
 
   <div class="timeline">
@@ -239,14 +239,14 @@ title: My Journey
 
     <div class="tl-entry">
       <div class="tl-tag">senior &middot; 2020</div>
-      <h3 class="tl-title">Senior Cloud Engineer, Allied World</h3>
+      <h3 class="tl-title">AVP, Senior Cloud Engineer, Allied World</h3>
       <p class="tl-desc">Modernized engineering practices by building cloud-native IaC tooling with Terragrunt/Terraform. Created a custom CI/CD CodePipeline module that saved thousands of manual person-hours by automating plan on PR open and apply on merge.</p>
       <span class="tl-badge badge-ok">SHIPPED ✓</span>
     </div>
 
     <div class="tl-entry">
       <div class="tl-tag">promoted &middot; 2023</div>
-      <h3 class="tl-title">Lead Cloud Engineer, Allied World</h3>
+      <h3 class="tl-title">AVP, Lead Cloud Engineer, Allied World</h3>
       <p class="tl-desc">Built and led a distributed cloud engineering team. Replaced AWS-only CI/CD with a Unified DevOps Framework powered by GitHub Actions, adopted company-wide. Achieved a 5x productivity increase over individual contributions.</p>
       <span class="tl-badge badge-rank">▲ RANK UP</span>
     </div>


### PR DESCRIPTION
## Summary
- Replace "Silicon Alley" with "New York City" in the journey header to avoid readers thinking it's a typo for "Silicon Valley"
- Add AVP prefix to both Allied World titles (Senior Cloud Engineer and Lead Cloud Engineer)

## Test plan
- [x] Verify journey page header reads "From Santiago to New York City..."
- [x] Verify Allied World entries show "AVP, Senior Cloud Engineer" and "AVP, Lead Cloud Engineer"

🤖 Generated with [Claude Code](https://claude.com/claude-code)