### PR TITLE
Update journey origin/relocate copy and add LinkedIn to footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,8 @@
     <div class="container">
       <p>
         &copy; {{ 'now' | date: "%Y" }} Carlos Espejo &middot;
-        <a href="https://github.com/{{ site.github_username }}">GitHub</a>
+        <a href="https://github.com/{{ site.github_username }}">GitHub</a> &middot;
+        <a href="https://www.linkedin.com/in/carlos-espejo-6a48b618/">LinkedIn</a>
       </p>
     </div>
   </footer>

--- a/journey.html
+++ b/journey.html
@@ -172,14 +172,14 @@ title: My Journey
     <div class="tl-entry key">
       <div class="tl-tag">origin &middot; 1983</div>
       <h3 class="tl-title">Santiago, Dominican Republic</h3>
-      <p class="tl-desc">Born and raised on the island. Grew up resourceful. You figure things out when you have to.</p>
+      <p class="tl-desc">Born in Santiago. Left the island at 5 years old.</p>
       <span class="tl-badge badge-ok">ROOTS ✓</span>
     </div>
 
     <div class="tl-entry">
-      <div class="tl-tag">relocate &middot; 1985</div>
+      <div class="tl-tag">relocate &middot; 1988</div>
       <h3 class="tl-title">Sunset Park, Brooklyn</h3>
-      <p class="tl-desc">Moved to New York, settling in one of Brooklyn's most vibrant immigrant neighborhoods. The kind of place that teaches you to hustle.</p>
+      <p class="tl-desc">Landed in one of Brooklyn's most vibrant immigrant neighborhoods. Grew up resourceful. You learn to figure things out when you have to. The kind of place that teaches you to hustle.</p>
       <span class="tl-badge badge-ok">NYC ✓</span>
     </div>
 


### PR DESCRIPTION
## Summary
- Tighten origin entry: "Born in Santiago. Left the island at 5 years old."
- Update relocate year to 1988 with improved copy and consistent tense
- Add LinkedIn profile link to site footer alongside GitHub

## Test plan
- [x] Verify journey page origin and relocate sections display correctly
- [x] Verify LinkedIn link in footer opens correct profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)